### PR TITLE
Fix duplicate date field on professor user form

### DIFF
--- a/src/app/professor/page.tsx
+++ b/src/app/professor/page.tsx
@@ -653,13 +653,6 @@ export default function ProfessorPage() {
                         className="p-2 border border-gray-300 rounded"
                       />
                     )}
-                    <input
-                      type="date"
-                      placeholder="Data de Nascimento"
-                      value={userForm.dataNascimento?.substring(0, 10) || ""}
-                      onChange={(e) => handleUserFormChange("dataNascimento", e.target.value)}
-                      className="p-2 border border-gray-300 rounded"
-                    />
                     <select
                       value={userForm.statusValidacao ? "true" : "false"}
                       onChange={(e) =>


### PR DESCRIPTION
## Summary
- remove second `Data de Nascimento` input so the professor form only has one birthdate field

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684818e250e48320b54abb5c1ae81329